### PR TITLE
ContentCheckMojo marked as threadsafe

### DIFF
--- a/src/main/java/net/sf/buildbox/maven/contentcheck/ContentCheckMojo.java
+++ b/src/main/java/net/sf/buildbox/maven/contentcheck/ContentCheckMojo.java
@@ -12,6 +12,7 @@ import org.apache.maven.plugin.MojoFailureException;
  *
  * @goal check
  * @phase verify
+ * @threadSafe
  */
 public class ContentCheckMojo extends AbstractArchiveContentMojo {
     


### PR DESCRIPTION
This allows to run the goal in parallel without warnings.
