### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: false
 jdk:
    - openjdk7
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-   - openjdk7
+   - openjdk8
 notifications:
   email:
     recipients:


### PR DESCRIPTION
https://docs.travis-ci.com/user/reference/trusty/ says:
Container-based infrastructure is currently being deprecated. Please
remove any `sudo:` false keys in your `.travis.yml` file to use the
default fully-virtualized Linux infrastructure instead.

Also raise JDK version - doc says that minimum supported is now JDK 8:
https://docs.travis-ci.com/user/reference/xenial/